### PR TITLE
fix: specify container names, fix permissions and host access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ networks:
   directory-net:
   nodes:
   backend-directory-net:
+
+volumes:
+  db_data:
+  db_backup:
+
 services:
 # ----------------------------------------- Logion node 1 --------------------------------------------------------------
   private-database1:
@@ -16,7 +21,7 @@ services:
     networks:
       - node1-net
     volumes:
-      - ./db_data:/var/lib/postgresql/data/
+      - db_data:/var/lib/postgresql/data/
       - ./postgres.conf:/etc/postgresql/postgresql.conf
     command: [ "-c",  "config_file=/etc/postgresql/postgresql.conf" ]
   backup_manager1:
@@ -27,7 +32,7 @@ services:
       - ipfs-cluster1
     environment:
       - ENC_PASSWORD=secret
-      - LOG_DIRECTORY=/opt/logion-pg-backup-manager/log/
+      - LOG_DIRECTORY=/opt/logion-pg-backup-manager/db_data/log/
       - PG_USER=postgres
       - PG_DATABASE=postgres
       - PG_HOST=private-database1
@@ -44,8 +49,8 @@ services:
       - node1-net
       - nodes
     volumes:
-      - ./db_backup:/opt/logion-pg-backup-manager/work
-      - ./db_data/log:/opt/logion-pg-backup-manager/log/
+      - db_backup:/opt/logion-pg-backup-manager/work
+      - db_data:/opt/logion-pg-backup-manager/db_data
       - ./config/.pgpass:/root/.pgpass
   node1:
     container_name: logion-test_node1_1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ networks:
 services:
 # ----------------------------------------- Logion node 1 --------------------------------------------------------------
   private-database1:
+    container_name: logion-test_private-database1_1
     image: logionnetwork/logion-postgres:${PG_TAG:-latest}
     environment:
       - POSTGRES_PASSWORD=secret
@@ -19,6 +20,7 @@ services:
       - ./postgres.conf:/etc/postgresql/postgresql.conf
     command: [ "-c",  "config_file=/etc/postgresql/postgresql.conf" ]
   backup_manager1:
+    container_name: logion-test_backup_manager1_1
     image: logionnetwork/logion-pg-backup-manager:${BM_TAG:-latest}
     depends_on:
       - private-database1
@@ -46,6 +48,7 @@ services:
       - ./db_data/log:/opt/logion-pg-backup-manager/log/
       - ./config/.pgpass:/root/.pgpass
   node1:
+    container_name: logion-test_node1_1
     image: logionnetwork/logion-node:${NODE_TAG:-latest}
     environment:
       - NODE_KEY=c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a
@@ -55,6 +58,7 @@ services:
       - node1-net
       - nodes
   backend1:
+    container_name: logion-test_backend1_1
     image: logionnetwork/logion-backend:${BACKEND_TAG:-latest}
     environment:
       - JWT_SECRET=c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a
@@ -78,6 +82,7 @@ services:
       - backend-directory-net
       - nodes
   frontend1:
+    container_name: logion-test_frontend1_1
     image: logionnetwork/logion-frontend:${FRONTEND_TAG:-latest}
     ports:
       - 127.0.0.1:8080:80
@@ -95,6 +100,7 @@ services:
     networks:
       - node1-net
   ipfs1:
+    container_name: logion-test_ipfs1_1
     image: ipfs/go-ipfs:v0.12.0
     ports:
       - 127.0.0.1:5001:5001
@@ -106,6 +112,7 @@ services:
     networks:
       - nodes
   ipfs-cluster1:
+    container_name: logion-test_ipfs-cluster1_1
     image: ipfs/ipfs-cluster:v0.14.5
     depends_on:
       - ipfs1
@@ -118,12 +125,14 @@ services:
       - nodes
 # ----------------------------------------- Logion node 2 --------------------------------------------------------------
   private-database2:
+    container_name: logion-test_private-database2_1
     image: logionnetwork/logion-postgres:${PG_TAG:-latest}
     environment:
       - POSTGRES_PASSWORD=secret
     networks:
       - node2-net
   node2:
+    container_name: logion-test_node2_1
     image: logionnetwork/logion-node:${NODE_TAG:-latest}
     environment:
       - NODE_KEY=6ce3be907dbcabf20a9a5a60a712b4256a54196000a8ed4050d352bc113f8c58
@@ -135,6 +144,7 @@ services:
       - node2-net
       - nodes
   backend2:
+    container_name: logion-test_backend2_1
     image: logionnetwork/logion-backend:${BACKEND_TAG:-latest}
     environment:
       - JWT_SECRET=6ce3be907dbcabf20a9a5a60a712b4256a54196000a8ed4050d352bc113f8c58
@@ -158,6 +168,7 @@ services:
       - backend-directory-net
       - nodes
   frontend2:
+    container_name: logion-test_frontend2_1
     image: logionnetwork/logion-frontend:${FRONTEND_TAG:-latest}
     ports:
       - 127.0.0.1:8081:80
@@ -175,6 +186,7 @@ services:
     networks:
       - node2-net
   ipfs2:
+    container_name: logion-test_ipfs2_1
     image: ipfs/go-ipfs:v0.12.0
     volumes:
       - ./config/ipfs2/config:/data/ipfs/config:ro
@@ -186,6 +198,7 @@ services:
     depends_on:
       - ipfs1
   ipfs-cluster2:
+    container_name: logion-test_ipfs2-cluster2_1
     image: ipfs/ipfs-cluster:v0.14.5
     depends_on:
       - ipfs-cluster1
@@ -197,12 +210,14 @@ services:
       - nodes
 # ----------------------------------------- Logion node 3 --------------------------------------------------------------
   private-database3:
+    container_name: logion-test_private-database3_1
     image: logionnetwork/logion-postgres:${PG_TAG:-latest}
     environment:
       - POSTGRES_PASSWORD=secret
     networks:
       - node3-net
   node3:
+    container_name: logion-test_node3_1
     image: logionnetwork/logion-node:${NODE_TAG:-latest}
     environment:
       - NODE_KEY=3a9d5b35b9fb4c42aafadeca046f6bf56107bd2579687f069b42646684b94d9e
@@ -214,6 +229,7 @@ services:
       - node3-net
       - nodes
   backend3:
+    container_name: logion-test_backend3_1
     image: logionnetwork/logion-backend:${BACKEND_TAG:-latest}
     environment:
       - JWT_SECRET=3a9d5b35b9fb4c42aafadeca046f6bf56107bd2579687f069b42646684b94d9e
@@ -237,6 +253,7 @@ services:
       - backend-directory-net
       - nodes
   frontend3:
+    container_name: logion-test_fromtend3_1
     image: logionnetwork/logion-frontend:${FRONTEND_TAG:-latest}
     ports:
       - 127.0.0.1:8082:80
@@ -254,6 +271,7 @@ services:
     networks:
       - node3-net
   ipfs3:
+    container_name: logion-test_ipfs3_1
     image: ipfs/go-ipfs:v0.12.0
     volumes:
       - ./config/ipfs3/config:/data/ipfs/config:ro
@@ -276,12 +294,14 @@ services:
       - nodes
 # ----------------------------------------- Logion directory --------------------------------------------------------------
   directory-database:
+    container_name: logion-test_directory-database_1
     image: postgres:12
     environment:
       - POSTGRES_PASSWORD=secret
     networks:
       - directory-net
   directory:
+    container_name: logion-test_directory_1
     image: logionnetwork/logion-directory:${DIRECTORY_TAG:-latest}
     ports:
       - 127.0.0.1:8090:8080

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-docker-compose down
-rm -rf db_backup db_data
+docker-compose down -v

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -3,4 +3,4 @@
 set -e
 
 docker-compose down
-sudo rm -rf db_backup db_data
+rm -rf db_backup db_data

--- a/scripts/restore_demo.sh
+++ b/scripts/restore_demo.sh
@@ -12,14 +12,14 @@ function print_section()
 
 # Kill node1's private database
 print_section "Killing node1..."
-docker-compose stop backup_manager1
 docker-compose stop private-database1
+docker exec -i logion-test_backup_manager1_1 /bin/sh -c 'rm -Rf /opt/logion-pg-backup-manager/db_data/*'
+docker-compose stop backup_manager1
 docker-compose rm -f private-database1
-sudo rm -rf db_data # Deletes DB state
 
 # Re-create node1's private database
 print_section "Restoring node1..."
 docker-compose up -d private-database1
 sleep 1 # Wait for postgres to be ready
-echo "Restore" | sudo tee db_backup/command.txt > /dev/null # Trigger Restore on next backup manager trigger
 docker-compose start backup_manager1
+docker exec -i logion-test_backup_manager1_1 /bin/sh -c 'echo "Restore" > /opt/logion-pg-backup-manager/work/command.txt'

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-mkdir -p db_data db_backup
 docker-compose up -d private-database1
 sleep 1 # Wait for postgres to be ready
 chmod 600 config/.pgpass # Without this, the pg clients used by the backup manager will fail

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-mkdir -p db_data
-sudo chown -R 999:999 db_data # Make sure that the directory has proper ownership for the postgresql container
+mkdir -p db_data db_backup
 docker-compose up -d private-database1
 sleep 1 # Wait for postgres to be ready
 chmod 600 config/.pgpass # Without this, the pg clients used by the backup manager will fail
@@ -11,8 +10,4 @@ docker-compose up -d
 
 sleep 3 # Wait for the directory service to be up
 
-DIRECTORY_DB_HOST_IP=$(docker inspect logion-test_directory-database_1 | jq -r '.[0].NetworkSettings.Networks."logion-test_directory-net".IPAddress')
-
-export PGPASSWORD=secret
-psql -h $DIRECTORY_DB_HOST_IP -p 5432 -U postgres postgres < scripts/directory_data.sql
-unset PGPASSWORD
+docker exec -i logion-test_directory-database_1 psql -U postgres postgres < scripts/directory_data.sql


### PR DESCRIPTION
Fixed 3 different issues to be able to startup on my env : 
- container names need to be specified, as the default names generated by docker-compose v1 and v2 are differents ( v2 generates `logion-test-private-database1-1` where v1 used `logion-test_private-database1_1` - see https://stackoverflow.com/a/69519102 )
- host is usually not able to see container internal ips ( unless the network is bridged somehow ? ), so the psql command was not able to connect. executing psql directly inside the container is actually easier and should work in all cases.
- we should not need to change the owner of the mounted directory on the host - at least not when using volumes mounted with gRPC fuse, which stores container file owner in separate file attributes. Actually on my side it creates permissions issues. However I'm not sure if grpc fuse is set as default in docker on all platforms ? Maybe it would be easier to use a local volume instead of a bind mount, as we don't really need to have the content of db_data available on the host ?